### PR TITLE
fixed badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 rmr_test_repo
 ==============================
 [//]: # (Badges)
-[![GitHub Actions Build Status](https://github.com/REPLACE_WITH_OWNER_ACCOUNT/rmr_test_repo/workflows/CI/badge.svg)](https://github.com/REPLACE_WITH_OWNER_ACCOUNT/rmr_test_repo/actions?query=workflow%3ACI)
-[![codecov](https://codecov.io/gh/REPLACE_WITH_OWNER_ACCOUNT/rmr_test_repo/branch/main/graph/badge.svg)](https://codecov.io/gh/REPLACE_WITH_OWNER_ACCOUNT/rmr_test_repo/branch/main)
+[![GitHub Actions Build Status](https://github.com/SIMCODES-ISU/rmr_test_repo/workflows/CI/badge.svg)](https://github.com/REPLACE_WITH_OWNER_ACCOUNT/rmr_test_repo/actions?query=workflow%3ACI)
+[![codecov](https://codecov.io/gh/SIMCODES-ISU/rmr_test_repo/branch/main/graph/badge.svg)](https://codecov.io/gh/SIMCODES-ISU/rmr_test_repo/branch/main)
 
 
 a test repo
 
 ### Copyright
 
-Copyright (c) 2025, simcodes
+Copyright (c) 2025, SIMCODES-ISU
 
 
 #### Acknowledgements


### PR DESCRIPTION
## Description
At present the badges on the README are broken. This PR fixes them by changing `REPLACE_WITH_OWNER_ACCOUNT` to `SIMCODES-ISU`.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Fixed the badges

## Questions
N/A

## Status
- [x] Ready to go